### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,4 +1,6 @@
 name: Daily YouTube Upload
+permissions:
+  contents: read
 on:
   schedule:
     - cron: '0 12 * * *'  # Runs at noon UTC daily


### PR DESCRIPTION
Potential fix for [https://github.com/1stofhis/YTAI/security/code-scanning/1](https://github.com/1stofhis/YTAI/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. Since the workflow only checks out code, installs dependencies, and runs a Python script, it likely only requires `contents: read` permissions. This change ensures the workflow operates with minimal privileges, reducing the risk of unauthorized actions.

The `permissions` block should be added at the root level of the workflow file, applying to all jobs in the workflow. This avoids redundancy and ensures consistency across jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
